### PR TITLE
Add Amazon Q Developer CLI to list of compatible agents

### DIFF
--- a/components/CompatibilitySection.tsx
+++ b/components/CompatibilitySection.tsx
@@ -112,6 +112,12 @@ export default function CompatibilitySection() {
       imageSrcLight: "/logos/devin-light.svg",
       imageSrcDark: "/logos/devin-dark.svg",
     },
+    {
+      name: "Q Developer CLI",
+      from: "Amazon",
+      url: "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html",
+      imageSrc: "/logos/q-developer.svg",
+    },
 
   ];
   return (

--- a/public/logos/q-developer.svg
+++ b/public/logos/q-developer.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="100%" width="100%" fill="none" viewBox="0 0 48 48" style="width: 70px;">
+  <defs>
+    <linearGradient id="linear-gradient" x1="43.37" y1="-3.59" x2="7.13" y2="48.17" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#a7f8ff"></stop>
+      <stop offset=".03" stop-color="#9df1ff"></stop>
+      <stop offset=".08" stop-color="#84e1ff"></stop>
+      <stop offset=".15" stop-color="#5ac7ff"></stop>
+      <stop offset=".22" stop-color="#21a2ff"></stop>
+      <stop offset=".26" stop-color="#008dff"></stop>
+      <stop offset=".66" stop-color="#7f33ff"></stop>
+      <stop offset=".99" stop-color="#39127d"></stop>
+    </linearGradient>
+    <mask id="mask">
+      <rect width="100%" height="100%" fill="white"/>
+      <path d="m36.64,14.66l-10.79-6.23c-.49-.29-1.15-.43-1.8-.43s-1.3.14-1.8.43l-10.79,6.23c-.99.57-1.8,1.97-1.8,3.11v12.46c0,1.14.81,2.54,1.8,3.11l10.79,6.23c.49.29,1.15.43,1.8.43s1.3-.14,1.8-.43l10.79-6.23c.99-.57,1.8-1.97,1.8-3.11v-12.46c0-1.14-.81-2.54-1.8-3.11Zm-12.3,22.33s-.14.03-.28.03-.24-.02-.28-.03l-10.82-6.25c-.11-.1-.25-.35-.28-.49v-12.5c.03-.14.18-.39.28-.49l10.82-6.25s.14-.03.28-.03.24.02.28.03l10.82,6.25c.11.1.25.35.28.49v11.09l-8.38-4.84v-1.32c0-.26-.14-.49-.36-.62l-2.28-1.32c-.11-.06-.24-.1-.36-.1s-.25.03-.36.1l-2.28,1.32c-.22.13-.36.37-.36.62v2.63c0,.26.14.49.36.62l2.28,1.32c.11.06.24.1.36.1s.25-.03.36-.1l1.14-.66,8.38,4.84-9.6,5.54Z" fill="black" stroke-width="0"/>
+    </mask>
+  </defs>
+  <path d="m20.37.99L5.97,9.3c-2.28,1.32-3.69,3.75-3.69,6.39v16.63c0,2.63,1.41,5.07,3.69,6.39l14.4,8.31c2.28,1.32,5.09,1.32,7.37,0l14.4-8.31c2.28-1.32,3.69-3.75,3.69-6.39V15.69c0-2.63-1.41-5.07-3.69-6.39L27.74.99c-2.28-1.32-5.09-1.32-7.37,0Z" fill="url(#linear-gradient)" stroke-width="0" mask="url(#mask)"/>
+</svg>


### PR DESCRIPTION
Since version 1.16.0 released on September 16, Amazon Q Developer CLI checks AGENTS.md by default. As far as I know the official documentation hasn't been updated yet but here's the relevant pull request: https://github.com/aws/amazon-q-developer-cli/pull/2812