### PR TITLE
Add local .agents.md

### DIFF
--- a/components/FAQSection.tsx
+++ b/components/FAQSection.tsx
@@ -17,7 +17,7 @@ export default function FAQ() {
     {
       question: "What if instructions conflict?",
       answer: 
-        ".agentsmd beats conflicting guidance in AGENTS.md. The closest instruction file to the edited file wins; explicit user chat prompts override everything.",
+        ".agents.md beats conflicting guidance in AGENTS.md. The closest instruction file to the edited file wins; explicit user chat prompts override everything.",
     },
     {
       question: "Will the agent run testing commands found in AGENTS.md automatically?",

--- a/components/HowToUseSection.tsx
+++ b/components/HowToUseSection.tsx
@@ -32,8 +32,8 @@ export default function HowToUseSection() {
       body: "Commit messages or pull request guidelines, security gotchas, large datasets, deployment steps: anything you’d tell a new teammate belongs here too.",
     },
     {
-      title: "Add local instructions with .agentsmd",
-      body: "Keep personal rules in a sibling .agentsmd file. Agents read both files, give priority to .agentsmd, and apply the same \"closest file wins\" hierarchy.",
+      title: "Add local instructions with .agents.md",
+      body: "Keep personal rules in a sibling .agents.md file. Agents read both files, give priority to .agents.md, and apply the same \"closest file wins\" hierarchy.",
     },
     {
       title: "Large monorepo? Use nested AGENTS.md files for subprojects",


### PR DESCRIPTION
Fixes #72 
Adds `.agents.md` files for defining local instructions. These sit beside `AGENTS.md` files and are intended to not be git-tracked.