### PR TITLE
Remove `PlutoLang/Pluto` hardocoded example due to missing AGENTS.md

### DIFF
--- a/components/ExampleListSection.tsx
+++ b/components/ExampleListSection.tsx
@@ -37,11 +37,6 @@ const REPOS: RepoCardProps[] = [
       "Java SDK for Temporal, workflow orchestration defined in code.",
     language: "Java",
   },
-  {
-    name: "PlutoLang/Pluto",
-    description: "A superset of Lua 5.4 with a focus on general-purpose programming.",
-    language: "C++",
-  },
 ];
 
 interface ExampleListSectionProps {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,6 @@ export const getStaticProps: GetStaticProps<LandingPageProps> = async () => {
     "openai/codex",
     "apache/airflow",
     "temporalio/sdk-java",
-    "PlutoLang/Pluto",
   ];
 
   // If we fetched within the last 12 hours, reuse the cached data.


### PR DESCRIPTION
When following the link
https://github.com/PlutoLang/Pluto/blob/-/AGENTS.md it shows a 404
error. The file is missing on their project.
