### PR TITLE
fix: rename map parameter from 'key' to 'index' for clarity

### DIFF
--- a/components/ExampleListSection.tsx
+++ b/components/ExampleListSection.tsx
@@ -56,13 +56,13 @@ const InnerGrid = ({
 }) => (
   <>
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-      {REPOS.map((repo, key) => (
+      {REPOS.map((repo, index) => (
         <ExampleCard
           key={repo.name}
           repo={repo}
           avatars={contributorsByRepo[repo.name]?.avatars ?? []}
-          hideOnSmall={key > 3}
-          hideOnMedium={key > 2}
+          hideOnSmall={index > 3}
+          hideOnMedium={index > 2}
           totalContributors={
             contributorsByRepo[repo.name]?.total ??
             contributorsByRepo[repo.name]?.avatars.length ??


### PR DESCRIPTION
## Summary
- Rename the second parameter of `Array.map()` from `key` to `index` in `ExampleListSection` component
- This improves code readability and avoids confusion with React's `key` prop
- Makes the intent clearer that this is the array index being used for conditional rendering

## Changes
- Updated `components/ExampleListSection.tsx` to use `index` instead of `key` as the map callback parameter
- Updated usages in `hideOnSmall` and `hideOnMedium` props

## Test plan
- [x] Build passes successfully (`npm run build`)
- [x] No functional changes - this is purely a naming improvement for code clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)