### PR TITLE
Replace broken PlutoLang/Pluto example with ggml-org/llama.cpp

### DIFF
--- a/components/ExampleListSection.tsx
+++ b/components/ExampleListSection.tsx
@@ -38,8 +38,8 @@ const REPOS: RepoCardProps[] = [
     language: "Java",
   },
   {
-    name: "PlutoLang/Pluto",
-    description: "A superset of Lua 5.4 with a focus on general-purpose programming.",
+    name: "ggml-org/llama.cpp",
+    description: "LLM inference in C/C++.",
     language: "C++",
   },
 ];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,7 @@ export const getStaticProps: GetStaticProps<LandingPageProps> = async () => {
     "openai/codex",
     "apache/airflow",
     "temporalio/sdk-java",
-    "PlutoLang/Pluto",
+    "ggml-org/llama.cpp",
   ];
 
   // If we fetched within the last 12 hours, reuse the cached data.


### PR DESCRIPTION
## What changed

- **[components/ExampleListSection.tsx](components/ExampleListSection.tsx)** — Replaced `PlutoLang/Pluto` entry with `ggml-org/llama.cpp` in the `REPOS` array
- **[pages/index.tsx](pages/index.tsx)** — Updated the `repoNames` list in `getStaticProps` to match

## Why

PlutoLang/Pluto removed their AGENTS.md file (renamed to CONTRIBUTING.md in https://github.com/PlutoLang/Pluto/pull/1387), causing the example tile on the website to link to a 404.

The issue (#93) asks to replace with a C++ repo that still uses AGENTS.md. `ggml-org/llama.cpp` is an ideal replacement:
- 96k+ stars, actively maintained
- Primary language is C/C++
- Has a well-written [AGENTS.md](https://github.com/ggml-org/llama.cpp/blob/master/AGENTS.md) at root

## How verified

- TypeScript: zero type errors (verified via IDE)
- Lint: zero errors
- Verified `ggml-org/llama.cpp` has AGENTS.md at root via GitHub API
- Verified the link `https://github.com/ggml-org/llama.cpp/blob/-/AGENTS.md` resolves correctly

## Tradeoffs / risks

- `ggml-org/llama.cpp` could remove their AGENTS.md in the future (same risk any featured example has)

## Scope notes

- Changes strictly limited to replacing the broken link
- No additional refactors or changes

## Related

- Fixes #93
- Supersedes #117 (which removes the entry instead of replacing it)