### PR TITLE
Add tbd-vote-cli to AGENTS.md examples

### DIFF
--- a/components/ExampleListSection.tsx
+++ b/components/ExampleListSection.tsx
@@ -42,6 +42,11 @@ const REPOS: RepoCardProps[] = [
     description: "A superset of Lua 5.4 with a focus on general-purpose programming.",
     language: "C++",
   },
+  {
+    name: "ego-protocol/tbd-vote-cli",
+    description: "Solana prediction market with an AGENTS.md-driven agent CLI for trading opinion polls.",
+    language: "TypeScript",
+  },
 ];
 
 interface ExampleListSectionProps {


### PR DESCRIPTION
Adds [tbd-vote-cli](https://github.com/ego-protocol/tbd-vote-cli) to the "Who uses AGENTS.md?" examples in `components/ExampleListSection.tsx`.

**TBD Predict** ([tbd.vote](https://www.tbd.vote)) is a Solana-based prediction market for human opinions. The `@tbd-vote/cli` npm package and the [AGENTS.md spec](https://www.tbd.vote/agents/AGENTS.md) it ships with let AI agents authenticate, browse opinion campaigns, and place bets via JSON-friendly commands — including a documented autonomous-loop pattern and a raw HTTP fallback.

This project leans heavily on the AGENTS.md format as the primary source of truth for any agent integrating with the platform, which feels like a clean fit for the examples list. It also adds a different domain (prediction-market / agent-actionable service) to the existing mix of CLI tooling, workflow infrastructure, and language projects.

Notes:
- This adds a 5th entry. Per the existing grid hide rules in `ExampleListSection.tsx`, the 5th card will only appear on `lg+` screens — happy to swap one out instead if you'd prefer to keep it at 4.
- AGENTS.md content lives at https://www.tbd.vote/agents/AGENTS.md (a stable URL), so the link is durable.

Links:
- Website: https://www.tbd.vote
- CLI repo: https://github.com/ego-protocol/tbd-vote-cli
- AGENTS.md: https://www.tbd.vote/agents/AGENTS.md
- npm: https://www.npmjs.com/package/@tbd-vote/cli