### PR TITLE
docs: add DELEGATION.md proposal note

### DIFF
--- a/DELEGATION.md
+++ b/DELEGATION.md
@@ -1,0 +1,35 @@
+# Sample DELEGATION.md file
+
+## Principal
+- Support operations team
+- Human approval required for financial, legal, or physical actions
+
+## Allowed actions
+- Read order history
+- Draft refund recommendations
+- Issue refunds up to $50
+
+## Forbidden actions
+- Send customer emails without fresh approval
+- Change account ownership
+- Export bulk customer data
+
+## Allowed delegatees
+- triage-agent
+- policy-agent
+- refund-tool
+
+## Delegation limits
+- Max depth: 2
+- Expiry: session-bound
+- Scope expansions require reauthorization
+
+## Reauthorization triggers
+- Read -> write
+- Draft -> send
+- New tool or dataset
+- Higher-privilege credential
+
+## Audit
+- Attach an authorization receipt to every delegated action
+- Preserve append-only hop history

--- a/README.md
+++ b/README.md
@@ -47,3 +47,25 @@ that explains the project’s goals in a simple way, and featuring some examples
    pnpm run dev
    ```
 3. Open your browser and go to http://localhost:3000
+
+## Adjacent Idea: DELEGATION.md
+
+An adjacent idea I have been exploring is **DELEGATION.md**: a plain Markdown
+companion to `AGENTS.md` for describing what an agent is allowed to do.
+
+The rough split looks like this:
+
+- `AGENTS.md` tells an agent how to work
+- `DELEGATION.md` tells an agent what authority it has
+
+That can be useful once work starts moving across tools, sub-agents, or other
+trust boundaries and you want to make allowed actions, forbidden actions,
+delegatees, ceilings, and reauthorization rules visible in one place.
+
+There is a sample [`DELEGATION.md`](./DELEGATION.md) file in this fork.
+
+For a runtime provenance/enforcement layer, see **HDP (Human Delegation
+Provenance)**:
+
+- Paper: [arXiv:2604.04522](https://arxiv.org/abs/2604.04522)
+- Overview: [Helixar Labs - HDP](https://helixar.ai/about/labs/hdp/)


### PR DESCRIPTION
## What this adds

This PR adds a small, additive proposal note for **DELEGATION.md** and a sample `DELEGATION.md` file.

The idea is simple:

- `AGENTS.md` tells an agent how to work
- `DELEGATION.md` would describe what authority it has

## Why

One thing that still feels under-specified in agent workflows is authority:

- which actions are allowed
- which actions are forbidden
- which delegatees or tools are in scope
- when fresh human approval is required
- where read-only turns into write access
- where drafting turns into sending or executing

This PR does **not** try to redefine `AGENTS.md`.
It just adds a short note in the README and a sample file in the fork to make the adjacent idea concrete.

## Scope

This is intentionally small:

- add `DELEGATION.md` sample file
- add a short README section describing the concept
- include HDP references as one possible runtime provenance/enforcement layer

No site components or existing project messaging are changed.

## References

- Paper: https://arxiv.org/abs/2604.04522
- Overview: https://helixar.ai/about/labs/hdp/

## Feedback I’d love

- whether this feels like a useful sibling concept to `AGENTS.md`
- whether `DELEGATION.md` is the right name
- whether this belongs as a separate proposal/repo rather than as a note here
