### PR TITLE
docs: add context budget guidance

### DIFF
--- a/components/FAQSection.tsx
+++ b/components/FAQSection.tsx
@@ -29,6 +29,11 @@ export default function FAQ() {
       answer: "Absolutely. Treat AGENTS.md as living documentation.",
     },
     {
+      question: "Should AGENTS.md include all project documentation?",
+      answer:
+        "No. Keep AGENTS.md focused on instructions an agent should usually load up front. Link to deeper docs for details that are only relevant to specific tasks.",
+    },
+    {
       question: "How do I migrate existing docs to AGENTS.md?",
       answer: (
         <>

--- a/components/HowToUseSection.tsx
+++ b/components/HowToUseSection.tsx
@@ -32,6 +32,17 @@ export default function HowToUseSection() {
       body: "Commit messages or pull request guidelines, security gotchas, large datasets, deployment steps: anything you’d tell a new teammate belongs here too.",
     },
     {
+      title: "Keep it focused",
+      body: (
+        <>
+          AGENTS.md is loaded into an agent’s context, so treat every line as part
+          of the context budget. Prefer durable, task-relevant guidance over long
+          overviews, and link to deeper docs when the agent only needs them for
+          specific tasks.
+        </>
+      ),
+    },
+    {
       title: "Large monorepo? Use nested AGENTS.md files for subprojects",
       body: (
         <>


### PR DESCRIPTION
Adds a small note that AGENTS.md is part of the agent context budget, so the default guidance should stay focused and link out to deeper docs when details are task-specific.

Why:
- Recent discussion around AGENTS.md effectiveness is making context cost more visible.
- The current page says "anything you'd tell a new teammate belongs here too", which is useful but can nudge people toward long up-front overviews.
- This keeps the format simple while encouraging durable, task-relevant instructions.

Checks:
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm run build`
- `git diff --check`
