### PR TITLE
Add FAQ: How do I configure Claude Code? (@AGENTS.md import)

### DIFF
--- a/components/FAQSection.tsx
+++ b/components/FAQSection.tsx
@@ -86,6 +86,26 @@ export default function FAQ() {
         </>
       ),
     },
+    {
+      question: "How do I configure Claude Code?",
+      answer: (
+        <>
+          <p className="mb-2">
+            Claude Code reads <code>CLAUDE.md</code> rather than <code>AGENTS.md</code>. Import
+            your AGENTS.md from <code>CLAUDE.md</code> with a one-line directive so there is a
+            single source of truth both tools share:
+          </p>
+          <div className="w-full flex justify-center">
+            <CodeExample
+              code="@AGENTS.md"
+              compact
+              heightClass="min-h-[48px]"
+              centerVertically
+            />
+          </div>
+        </>
+      ),
+    },
   ];
 
   return (


### PR DESCRIPTION
Adds a per-tool FAQ entry for **Claude Code**, mirroring the existing "How do I configure Aider?" and "How do I configure Gemini CLI?" entries.
Claude Code is one of the most widely used coding agents, but it had no entry in the FAQ. Unlike the tools already covered, Claude Code reads `CLAUDE.md` rather than `AGENTS.md` natively — so users frequently ask how to use an existing `AGENTS.md` with it.
The answer is the officially documented import: put a one-line `@AGENTS.md` directive at the top of `CLAUDE.md`, which keeps a single shared source of truth instead of duplicating the file. This is the `@path` import syntax from Anthropic's Claude Code memory documentation.
> **How do I configure Claude Code?**
> Claude Code reads `CLAUDE.md` rather than `AGENTS.md`. Import your AGENTS.md from `CLAUDE.md` with a one-line directive so there is a single source of truth both tools share:
> ```
> @AGENTS.md
> ```
Reuses the existing `CodeExample` component and matches the structure/formatting of the other per-tool config entries. `tsx` parses/transforms cleanly (verified with esbuild). No other files touched.