### PR TITLE
Add Loki Mode as an AGENTS.md adopter

### DIFF
--- a/components/CompatibilitySection.tsx
+++ b/components/CompatibilitySection.tsx
@@ -139,6 +139,13 @@ const agents: AgentEntry[] = [
     url: "https://jetbrains.com/junie",
     imageSrc: "/logos/junie.svg",
   },
+  {
+    name: "Loki Mode",
+    from: "Autonomi",
+    url: "https://github.com/asklokesh/loki-mode",
+    imageSrcLight: "/logos/loki-mode.svg",
+    imageSrcDark: "/logos/loki-mode.svg",
+  },
 ];
 
 const shuffleAgents = (items: AgentEntry[]) => {

--- a/public/logos/loki-mode.svg
+++ b/public/logos/loki-mode.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <!-- Loki Mode square icon: Autonomi A-mark reused as-is (purple square, white A, teal dot) -->
+  <!-- Brand palette: purple #553DE9, cream #FFFEFB, teal #1FC5A8 -->
+  <rect width="512" height="512" rx="0" fill="#553DE9"/>
+
+  <!-- Letter A - white elegant strokes (matches favicon.svg geometry) -->
+  <path d="M152 405 L242 120" stroke="#FFFEFB" stroke-width="28" stroke-linecap="round"/>
+  <path d="M360 405 L270 120" stroke="#FFFEFB" stroke-width="28" stroke-linecap="round"/>
+  <path d="M242 120 Q256 86 270 120" stroke="#FFFEFB" stroke-width="28" stroke-linecap="round" fill="none"/>
+
+  <!-- Teal verification dot -->
+  <circle cx="256" cy="295" r="20" fill="#1FC5A8"/>
+</svg>


### PR DESCRIPTION
Adds Loki Mode to the supported-agents list (components/CompatibilitySection.tsx).

Loki Mode is an autonomous spec-to-product coding agent. Its agents natively read AGENTS.md at the repository root for build/test/style conventions, falling back to CLAUDE.md only when AGENTS.md is absent (the two are never merged). That makes Loki an AGENTS.md consumer, the adopter category this list tracks.

Evidence (source links):
- Bash runtime: autonomy/run.sh lines 10555-10561 (the instruction string is at line 10561):
  https://github.com/asklokesh/loki-mode/blob/main/autonomy/run.sh#L10555-L10561
- Bun runtime (parity-locked copy): loki-ts/src/runner/build_prompt.ts (AGENTS_MD_INSTRUCTION), kept byte-identical to the bash string.

Added the entry to the `agents` array and committed a logo at public/logos/loki-mode.svg, matching the format of existing entries.

The logo is a self-contained colored tile (the Autonomi A-mark), so it reads on both light and dark backgrounds. I used the imageSrcLight/imageSrcDark fields (both pointing at the same SVG) so it renders in full color through next/image, consistent with the existing colored-logo entries (Ona, Devin, Windsurf, VS Code). Happy to switch to a single monochrome imageSrc silhouette or a separate light/dark pair if you prefer.
