### PR TITLE
fix: Replace Pluto with CarbonLang

### DIFF
--- a/components/ExampleListSection.tsx
+++ b/components/ExampleListSection.tsx
@@ -38,8 +38,8 @@ const REPOS: RepoCardProps[] = [
     language: "Java",
   },
   {
-    name: "PlutoLang/Pluto",
-    description: "A superset of Lua 5.4 with a focus on general-purpose programming.",
+    name: "carbon-language/carbon-lang",
+    description: "An experimental successor to C++.",
     language: "C++",
   },
 ];

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,7 @@ export const getStaticProps: GetStaticProps<LandingPageProps> = async () => {
     "openai/codex",
     "apache/airflow",
     "temporalio/sdk-java",
-    "PlutoLang/Pluto",
+    "carbon-language/carbon-lang",
   ];
 
   // If we fetched within the last 12 hours, reuse the cached data.


### PR DESCRIPTION
PlutoLang has no AGENTS.md file and when clicked it drops into 404 page. CarbonLang has 33k stars and it's another C++ project that has AGENTS.md file.