### PR TITLE
docs: add a Tooling section for utilities that work with AGENTS.md

### DIFF
--- a/components/ToolingSection.tsx
+++ b/components/ToolingSection.tsx
@@ -1,0 +1,24 @@
+import Section from "@/components/Section";
+
+const ToolingSection = () => (
+  <Section title="Tooling" className="pb-0" center maxWidthClass="max-w-3xl">
+    <p className="max-w-3xl">Utilities for working with AGENTS.md files:</p>
+
+    <p className="max-w-3xl mt-4">
+      <a
+        href="https://github.com/zackabrah/scopeglass"
+        className="underline hover:no-underline"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Scopeglass
+      </a>{" "}
+      &mdash; local CLI that shows the effective AGENTS.md chain for any path:
+      precedence order, line-level provenance, context-size estimates, and
+      checks for broken references, duplicates, and conflicting guidance.
+      Includes a CI gate (<code>scopeglass check</code>).
+    </p>
+  </Section>
+);
+
+export default ToolingSection;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import CompatibilitySection from "@/components/CompatibilitySection";
 import { GetStaticProps } from "next";
 import WhySection from "@/components/WhySection";
 import AboutSection from "@/components/AboutSection";
+import ToolingSection from "@/components/ToolingSection";
 
 interface LandingPageProps {
   contributorsByRepo: Record<string, { avatars: string[]; total: number }>;
@@ -25,6 +26,7 @@ export default function LandingPage({ contributorsByRepo }: LandingPageProps) {
         <HowToUseSection />
         <div className="flex-1 flex flex-col gap-4 mt-16">
           <AboutSection />
+          <ToolingSection />
           <FAQSection />
         </div>
       </main>


### PR DESCRIPTION
Disclosure: I'm the author of Scopeglass.

The site lists agents that consume the AGENTS.md format, but no supporting
tooling yet. This adds a small "Tooling" section (matching the AboutSection
component style) with one entry:

- [Scopeglass](https://github.com/zackabrah/scopeglass) — local CLI that
  shows the effective AGENTS.md chain for any path: precedence order,
  line-level provenance, context-size estimates, and checks for broken
  references, duplicates, and conflicting guidance. Includes a CI gate
  (`scopeglass check`).

No network calls, no model calls, MIT. Happy to trim this to a single FAQ
line instead if a dedicated section feels premature.

`npx tsc --noEmit` passes. `pnpm-lock.yaml` untouched.