### PR TITLE
docs: add verification evidence guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Below is a minimal example of an AGENTS.md file:
 - After moving files or changing imports, run `pnpm lint --filter <project_name>` to be sure ESLint and TypeScript rules still pass.
 - Add or update tests for the code you change, even if nobody asked.
 
+## Verification evidence
+- Run every command you cite from a clean checkout when practical.
+- In the PR description, list the exact commands you ran and whether they passed.
+- If a check could not run, say why and what remains unverified.
+- Do not claim a check passed based only on reading the code or another agent's report.
+
 ## PR instructions
 - Title format: [<project_name>] <Title>
 - Always run `pnpm lint` and `pnpm test` before committing.

--- a/components/CodeExample.tsx
+++ b/components/CodeExample.tsx
@@ -56,6 +56,12 @@ name>"\`.
 <project_name>\` to be sure ESLint and TypeScript rules still pass.
 - Add or update tests for the code you change, even if nobody asked.
 
+## Verification evidence
+- Run every command you cite from a clean checkout when practical.
+- In the PR description, list the exact commands you ran and whether they passed.
+- If a check could not run, say why and what remains unverified.
+- Do not claim a check passed based only on reading the code or another agent's report.
+
 ## PR instructions
 - Title format: [<project_name>] <Title>
 - Always run \`pnpm lint\` and \`pnpm test\` before committing.`;


### PR DESCRIPTION
## Summary

- add a compact Verification evidence section to the canonical `AGENTS.md` example
- keep the README and rendered site source synchronized
- ask contributors to report exact commands and results, disclose checks they could not run, and avoid unsupported success claims

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec tsc --noEmit`
- `git diff --check`
